### PR TITLE
Fix missing mouseclick definition in gamewindow

### DIFF
--- a/Game1.cs
+++ b/Game1.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
@@ -40,7 +40,6 @@ namespace TerraMine
             IsMouseVisible = true; // Сначала мышь видна
             Window.AllowUserResizing = true;
             Window.ClientSizeChanged += (s, e) => UpdateWindowCenter();
-            Window.MouseClick += (s, e) => CaptureMouse();
             // Настройка графики
             _graphics.PreferredBackBufferWidth = 1280;
             _graphics.PreferredBackBufferHeight = 720;


### PR DESCRIPTION
Remove unsupported `Window.MouseClick` event subscription to fix compilation error.

The `GameWindow` class in MonoGame does not expose a `MouseClick` event. Mouse input is correctly handled by polling the mouse state in the `Update` method, making this subscription redundant and erroneous.

---
<a href="https://cursor.com/background-agent?bcId=bc-7557ddc3-7e37-47e9-a6cc-e4e2bdb0b0cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7557ddc3-7e37-47e9-a6cc-e4e2bdb0b0cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

